### PR TITLE
Refactor metadata text extraction logic

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -99,7 +99,7 @@ export default {
       );
     },
     pageDescription: ({ heroSection, extractText }) => (
-      heroSection ? extractText(heroSection.content[0].inlineContent) : null
+      heroSection ? extractText(heroSection.content) : null
     ),
   },
   methods: {

--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -98,8 +98,8 @@ export default {
         undefined
       );
     },
-    pageDescription: ({ heroSection, extractText }) => (
-      heroSection ? extractText(heroSection.content) : null
+    pageDescription: ({ heroSection, extractFirstParagraphText }) => (
+      heroSection ? extractFirstParagraphText(heroSection.content) : null
     ),
   },
   methods: {

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -307,7 +307,9 @@ export default {
           && platforms.every(platform => platform.deprecatedAt)
         ),
     pageTitle: ({ title }) => title,
-    pageDescription: ({ abstract, extractText }) => extractText(abstract),
+    pageDescription: ({ abstract, extractText }) => (
+      abstract ? extractText(abstract) : null
+    ),
     // The `hierarchy.paths` array will contain zero or more subarrays, each
     // representing a "path" of parent topic IDs that could be considered the
     // hierarchy/breadcrumb for a given topic. We choose to render only the

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -307,8 +307,8 @@ export default {
           && platforms.every(platform => platform.deprecatedAt)
         ),
     pageTitle: ({ title }) => title,
-    pageDescription: ({ abstract, extractText }) => (
-      abstract ? extractText(abstract) : null
+    pageDescription: ({ abstract, extractFirstParagraphText }) => (
+      abstract ? extractFirstParagraphText(abstract) : null
     ),
     // The `hierarchy.paths` array will contain zero or more subarrays, each
     // representing a "path" of parent topic IDs that could be considered the

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -100,7 +100,7 @@ export default {
       );
     },
     pageDescription: ({ heroSection, extractText }) => (
-      heroSection ? extractText(heroSection.content[0].inlineContent) : null
+      heroSection ? extractText(heroSection.content) : null
     ),
   },
   props: {

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -99,8 +99,8 @@ export default {
         undefined
       );
     },
-    pageDescription: ({ heroSection, extractText }) => (
-      heroSection ? extractText(heroSection.content) : null
+    pageDescription: ({ heroSection, extractFirstParagraphText }) => (
+      heroSection ? extractFirstParagraphText(heroSection.content) : null
     ),
   },
   props: {

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -80,7 +80,7 @@ export default {
   computed: {
     pageTitle: ({ title }) => [title, 'Tutorials'].filter(Boolean).join(' '),
     pageDescription: ({ heroSection, extractText }) => (
-      extractText(heroSection.content[0].inlineContent)
+      heroSection ? extractText(heroSection.content) : null
     ),
     partitionedSections: ({ sections }) => sections.reduce(([heroes, others], section) => (
       section.kind === SectionKind.hero ? (

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -79,8 +79,8 @@ export default {
   },
   computed: {
     pageTitle: ({ title }) => [title, 'Tutorials'].filter(Boolean).join(' '),
-    pageDescription: ({ heroSection, extractText }) => (
-      heroSection ? extractText(heroSection.content) : null
+    pageDescription: ({ heroSection, extractFirstParagraphText }) => (
+      heroSection ? extractFirstParagraphText(heroSection.content) : null
     ),
     partitionedSections: ({ sections }) => sections.reduce(([heroes, others], section) => (
       section.kind === SectionKind.hero ? (

--- a/src/mixins/metadata.js
+++ b/src/mixins/metadata.js
@@ -16,7 +16,7 @@ export default {
   methods: {
     // Extracts the first paragraph of plaintext from the given content tree,
     // which can be used for metadata purposes.
-    extractText(content = []) {
+    extractFirstParagraphText(content = []) {
       const plaintext = ContentNode.computed.plaintext.bind({
         ...ContentNode.methods,
         content,

--- a/src/mixins/metadata.js
+++ b/src/mixins/metadata.js
@@ -9,11 +9,20 @@
 */
 
 import { addOrUpdateMetadata } from 'docc-render/utils/metadata';
+import { firstParagraph } from 'docc-render/utils/strings';
 import ContentNode from 'docc-render/components/ContentNode.vue';
 
 export default {
   methods: {
-    extractText: ContentNode.methods.extractText,
+    // Extracts the first paragraph of plaintext from the given content tree,
+    // which can be used for metadata purposes.
+    extractText(content = []) {
+      const plaintext = ContentNode.computed.plaintext.bind({
+        ...ContentNode.methods,
+        content,
+      })();
+      return firstParagraph(plaintext);
+    },
   },
   computed: {
     pagePath: ({ $route: { path = '/' } = {} }) => path,

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -210,3 +210,17 @@ export function whiteSpaceIgnorantRegex(stringToSanitize) {
 export function insertAt(str, sub, pos = 0) {
   return `${str.slice(0, pos)}${sub}${str.slice(pos)}`;
 }
+
+// Returns the first paragraph of the given text.
+//
+// @param {string} text - The full text.
+// @return {string} The first paragraph.
+//
+// Examples:
+//
+// firstParagraph("abcdefghi") // "abcdefghi"
+// firstParagraph("abc\ndef\nghi") // "abc"
+export function firstParagraph(text) {
+  const paragraphs = text.split(/(?:\r?\n)+/);
+  return paragraphs[0];
+}

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1062,25 +1062,6 @@ describe('ContentNode', () => {
     });
   });
 
-  describe('extractText', () => {
-    it('extracts and join all the texts using `extractText` method', () => {
-      const text = 'Description';
-      const texts = (nestedContent = {}) => ({
-        inlineContent: [{
-          type: 'text',
-          text,
-        },
-        nestedContent],
-      });
-
-      const coupleOfTexts = mountWithContent([texts(), texts()]).vm;
-      expect(coupleOfTexts.extractText(coupleOfTexts.content)).toEqual(text + text);
-
-      const nestedTexts = mountWithContent([texts(texts()), texts()]).vm;
-      expect(nestedTexts.extractText(nestedTexts.content)).toEqual(text + text + text);
-    });
-  });
-
   describe('.map', () => {
     it('recursively maps the content tree', () => {
       expect(mountWithContent([
@@ -1576,6 +1557,108 @@ describe('ContentNode', () => {
         ContentNode.BlockType.paragraph,
         ContentNode.InlineType.text,
       ]);
+    });
+  });
+
+  describe('.reduce', () => {
+    it('recursively reduces a function over each tree node', () => {
+      // A content node tree corresponding to the following markdown:
+      // a _*b*_ c
+      const wrapper = shallowMount(ContentNode, {
+        propsData: {
+          content: [
+            {
+              type: ContentNode.BlockType.paragraph,
+              inlineContent: [
+                {
+                  type: ContentNode.InlineType.text,
+                  text: 'a ',
+                },
+                {
+                  type: ContentNode.InlineType.emphasis,
+                  inlineContent: [
+                    {
+                      type: ContentNode.InlineType.strong,
+                      inlineContent: [
+                        {
+                          type: ContentNode.InlineType.text,
+                          text: 'b',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: ContentNode.InlineType.text,
+                  text: ' c',
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      // use reduce to combine all text from text nodes in the tree
+      const text = wrapper.vm.reduce((str, node) => (
+        node.type === ContentNode.InlineType.text ? `${str}${node.text}` : str
+      ), '');
+      expect(text).toBe('a b c');
+
+      // use reduce to count all the nodes in the tree
+      const count = wrapper.vm.reduce(num => num + 1, 0);
+      expect(count).toBe(6);
+
+      // use reduce to find all the unique node types in the tree
+      const types = wrapper.vm.reduce((set, node) => {
+        set.add(node.type);
+        return set;
+      }, new Set());
+      expect(types).toEqual(new Set([
+        ContentNode.BlockType.paragraph,
+        ContentNode.InlineType.text,
+        ContentNode.InlineType.emphasis,
+        ContentNode.InlineType.strong,
+      ]));
+    });
+  });
+
+  describe('.plaintext', () => {
+    it('returns the text equivalent of the content tree without inline formatting', () => {
+      const wrapper = shallowMount(ContentNode, {
+        propsData: {
+          content: [
+            {
+              type: ContentNode.BlockType.paragraph,
+              inlineContent: [
+                {
+                  type: ContentNode.InlineType.text,
+                  text: 'A',
+                },
+              ],
+            },
+            {
+              type: ContentNode.BlockType.paragraph,
+              inlineContent: [
+                {
+                  type: ContentNode.InlineType.strong,
+                  inlineContent: [
+                    {
+                      type: ContentNode.InlineType.emphasis,
+                      inlineContent: [
+                        {
+                          type: ContentNode.InlineType.text,
+                          text: 'B',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      expect(wrapper.vm.plaintext).toBe('A\nB');
     });
   });
 });

--- a/tests/unit/components/TutorialsOverview.spec.js
+++ b/tests/unit/components/TutorialsOverview.spec.js
@@ -35,6 +35,7 @@ describe('TutorialsOverview', () => {
             type: 'text',
             text: 'Hero description',
           }],
+          type: 'paragraph',
         }],
         image: 'foobar.png',
       },

--- a/tests/unit/mixins/metadata.spec.js
+++ b/tests/unit/mixins/metadata.spec.js
@@ -49,7 +49,7 @@ describe('metadata', () => {
     expect(addOrUpdateMetadata).toHaveBeenCalledWith(pageData);
   });
 
-  describe('.extractText', () => {
+  describe('.extractFirstParagraphText', () => {
     it('returns the the first paragraph of plaintext for a given content tree', () => {
       // A content node tree corresponding to the following markdown:
       // a _*b*_ c
@@ -92,9 +92,9 @@ describe('metadata', () => {
         },
       ];
       const wrapper = createWrapper(pageData);
-      expect(wrapper.vm.extractText(content)).toBe('a b c');
-      expect(wrapper.vm.extractText(content).includes('blah')).toBe(false);
-      expect(wrapper.vm.extractText([])).toBe('');
+      expect(wrapper.vm.extractFirstParagraphText(content)).toBe('a b c');
+      expect(wrapper.vm.extractFirstParagraphText(content).includes('blah')).toBe(false);
+      expect(wrapper.vm.extractFirstParagraphText([])).toBe('');
     });
   });
 });

--- a/tests/unit/mixins/metadata.spec.js
+++ b/tests/unit/mixins/metadata.spec.js
@@ -93,7 +93,6 @@ describe('metadata', () => {
       ];
       const wrapper = createWrapper(pageData);
       expect(wrapper.vm.extractFirstParagraphText(content)).toBe('a b c');
-      expect(wrapper.vm.extractFirstParagraphText(content).includes('blah')).toBe(false);
       expect(wrapper.vm.extractFirstParagraphText([])).toBe('');
     });
   });

--- a/tests/unit/mixins/metadata.spec.js
+++ b/tests/unit/mixins/metadata.spec.js
@@ -48,4 +48,53 @@ describe('metadata', () => {
     expect(addOrUpdateMetadata).toHaveBeenCalledTimes(1);
     expect(addOrUpdateMetadata).toHaveBeenCalledWith(pageData);
   });
+
+  describe('.extractText', () => {
+    it('returns the the first paragraph of plaintext for a given content tree', () => {
+      // A content node tree corresponding to the following markdown:
+      // a _*b*_ c
+      const content = [
+        {
+          type: 'paragraph',
+          inlineContent: [
+            {
+              type: 'text',
+              text: 'a ',
+            },
+            {
+              type: 'emphasis',
+              inlineContent: [
+                {
+                  type: 'strong',
+                  inlineContent: [
+                    {
+                      type: 'text',
+                      text: 'b',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'text',
+              text: ' c',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          inlineContent: [
+            {
+              type: 'text',
+              text: 'blah',
+            },
+          ],
+        },
+      ];
+      const wrapper = createWrapper(pageData);
+      expect(wrapper.vm.extractText(content)).toBe('a b c');
+      expect(wrapper.vm.extractText(content).includes('blah')).toBe(false);
+      expect(wrapper.vm.extractText([])).toBe('');
+    });
+  });
 });

--- a/tests/unit/mixins/metadata.spec.js
+++ b/tests/unit/mixins/metadata.spec.js
@@ -50,7 +50,7 @@ describe('metadata', () => {
   });
 
   describe('.extractFirstParagraphText', () => {
-    it('returns the the first paragraph of plaintext for a given content tree', () => {
+    it('returns the first paragraph of plaintext for a given content tree', () => {
       // A content node tree corresponding to the following markdown:
       // a _*b*_ c
       const content = [

--- a/tests/unit/utils/strings.spec.js
+++ b/tests/unit/utils/strings.spec.js
@@ -15,7 +15,9 @@ import {
   escapeRegExp,
   pluralize,
   deleteSpaces,
-  whiteSpaceIgnorantRegex, insertAt,
+  whiteSpaceIgnorantRegex,
+  insertAt,
+  firstParagraph,
 } from 'docc-render/utils/strings';
 
 describe('anchorize', () => {
@@ -230,5 +232,24 @@ describe('insertAt', () => {
   });
   it('inserts a string at an index', () => {
     expect(insertAt(base, insert, 2)).toBe('bafoose');
+  });
+});
+
+describe('firstParagraph', () => {
+  it('returns a string without paragraphs unchanged', () => {
+    expect(firstParagraph('')).toBe('');
+    expect(firstParagraph('abc')).toBe('abc');
+  });
+
+  it('handles Unix system newlines', () => {
+    expect(firstParagraph('abc\ndef\nghi')).toBe('abc');
+  });
+
+  it('handles Windows system newlines', () => {
+    expect(firstParagraph('abc\r\ndef\r\nghi')).toBe('abc');
+  });
+
+  it('returns an empty string if the character is a newline', () => {
+    expect(firstParagraph('\n')).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

This provides some cleaner abstractions for making generic transformations of content trees and updates the logic for grabbing the first paragraph of text for use as metadata descriptions to work better with varying author content.

Specific changes:
* adds a new `reduce` method to `ContentNode`
* adds a new `plaintext` computed property to `ContentNode`
* adds a new `firstParagraph` string utility
* updates the `extractText` mixin method to convert the content to plaintext and only use the first paragraph

\cc @dobromir-hristov

## Dependencies

https://github.com/apple/swift-docc-render/pull/46