### PR TITLE
Use absolute URLs for metadata

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,8 +18,6 @@
     <link rel="mask-icon" href="<%= BASE_URL %>favicon.svg" color="#333333">
     <title><%= process.env.VUE_APP_TITLE %></title>
     <script type="application/javascript">var baseUrl = "<%= BASE_URL %>"</script>
-    <meta property="og:image" content="<%= BASE_URL %>developer-og.jpg">
-    <meta name="twitter:image" content="<%= BASE_URL %>developer-og-twitter.jpg">
 </head>
 <body data-color-scheme="auto">
 <noscript><%= require('@/assets/global-elements/noscript.html') %></noscript>

--- a/src/utils/metadata.js
+++ b/src/utils/metadata.js
@@ -8,7 +8,7 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 import { getSetting } from 'docc-render/utils/theme-settings';
-import { normalizeAssetUrl } from 'docc-render/utils/assets';
+import { resolveAbsoluteUrl } from 'docc-render/utils/url-helper';
 
 const themeTitle = getSetting(['meta', 'title'], process.env.VUE_APP_TITLE);
 const createMetaTags = ({ title, description, path }) => [
@@ -38,7 +38,15 @@ const createMetaTags = ({ title, description, path }) => [
   },
   {
     property: 'og:url',
-    content: normalizeAssetUrl(path),
+    content: resolveAbsoluteUrl(path),
+  },
+  {
+    property: 'og:image',
+    content: resolveAbsoluteUrl('/developer-og.jpg'),
+  },
+  {
+    name: 'twitter:image',
+    content: resolveAbsoluteUrl('/developer-og-twitter.jpg'),
   },
   {
     name: 'twitter:card',
@@ -54,7 +62,7 @@ const createMetaTags = ({ title, description, path }) => [
   },
   {
     name: 'twitter:url',
-    content: normalizeAssetUrl(path),
+    content: resolveAbsoluteUrl(path),
   },
 ];
 const formatTitle = title => [title, themeTitle].filter(Boolean).join(' | ');

--- a/src/utils/url-helper.js
+++ b/src/utils/url-helper.js
@@ -8,6 +8,9 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// we should consider moving `normalizeAssetUrl` here and renaming it since it
+// is more generic than its name implies (no asset-specific logic)
+import { normalizeAssetUrl as normalizePath } from 'docc-render/utils/assets';
 import TechnologiesQueryParams from 'docc-render/constants/TechnologiesQueryParams';
 
 export function queryStringForParams(params = {}) {
@@ -64,4 +67,22 @@ export function areEquivalentLocations(routeA, routeB) {
     path: routeB.path,
     query: routeBQuery,
   }));
+}
+
+// Resolve a given relative path into a full, absolute URL.
+//
+// @param {String} relativePath A relative path.
+// @return {String} The absolute URL corresponding to the given path.
+//
+//
+// Note that the same call may result in different output for the same input
+// depending on where/how this instance of DocC-Render is being hosted.
+//
+// Example:
+//
+// resolveAbsoluteUrl('/foo/bar') // http://localhost:8080/foo/bar
+// resolveAbsoluteUrl('/foo/bar') // https://mportiz08.github.io/example/foo/bar
+//
+export function resolveAbsoluteUrl(relativePath) {
+  return new URL(normalizePath(relativePath), window.location.origin).href;
 }

--- a/src/utils/url-helper.js
+++ b/src/utils/url-helper.js
@@ -69,20 +69,24 @@ export function areEquivalentLocations(routeA, routeB) {
   }));
 }
 
-// Resolve a given relative path into a full, absolute URL.
+// Resolve a given path into a full, absolute URL.
 //
-// @param {String} relativePath A relative path.
-// @return {String} The absolute URL corresponding to the given path.
-//
+// @param {String} path A URL path.
+// @param {String} baseUrl An optional base URL to resolve against. The default
+//   value will be the origin of the current website.
+// @return {String} The absolute URL resulting from resolving the given path
+//   with the current website origin.
 //
 // Note that the same call may result in different output for the same input
 // depending on where/how this instance of DocC-Render is being hosted.
 //
-// Example:
+// Examples:
 //
 // resolveAbsoluteUrl('/foo/bar') // http://localhost:8080/foo/bar
+// OR
 // resolveAbsoluteUrl('/foo/bar') // https://mportiz08.github.io/example/foo/bar
 //
-export function resolveAbsoluteUrl(relativePath) {
-  return new URL(normalizePath(relativePath), window.location.origin).href;
+// resolveAbsoluteUrl('/foo/bar', 'http://example.com') // http://example.com/foo/bar
+export function resolveAbsoluteUrl(path, baseUrl = window.location.origin) {
+  return new URL(normalizePath(path), baseUrl).href;
 }

--- a/tests/unit/utils/metadata.spec.js
+++ b/tests/unit/utils/metadata.spec.js
@@ -15,7 +15,7 @@ const path = require('path');
 
 const html = fs.readFileSync(path.resolve(__dirname, '../../../app/index.html'));
 
-const mockBaseUrl = 'developer.com';
+const mockBaseUrl = 'developer';
 const title = 'Featured';
 const description = 'Browse the latest developer documentation, including tutorials, sample code, articles, and API reference.';
 const differentDescription = 'Some different description.';
@@ -76,6 +76,7 @@ const assertMetadata = ({
       expect(document.querySelector('meta[property="og:locale"]').content).toBe('en_US');
       expect(document.querySelector('meta[property="og:site_name"]').content).toBe(process.env.VUE_APP_TITLE);
       expect(document.querySelector('meta[property="og:type"]').content).toBe('website');
+      expect(document.querySelector('meta[property="og:image"]').content).toBe('http://localhost/developer/developer-og.jpg');
 
       // it adds twitter metadata tags
       if (expectedDescription) {
@@ -84,8 +85,8 @@ const assertMetadata = ({
         expect(document.querySelector('meta[name="twitter:description"]')).toBeFalsy();
       }
       expect(document.querySelector('meta[name="twitter:card"]').content).toBe('summary_large_image');
-      expect(document.querySelector('meta[name="twitter:image"]').content).toBe('<%= BASE_URL %>developer-og-twitter.jpg');
-      expect(document.querySelector('meta[name="twitter:url"]').content).toBe(mockBaseUrl + pagePath);
+      expect(document.querySelector('meta[name="twitter:image"]').content).toBe('http://localhost/developer/developer-og-twitter.jpg');
+      expect(document.querySelector('meta[name="twitter:url"]').content).toBe('http://localhost/developer/path');
     });
   });
 };

--- a/tests/unit/utils/url-helper.spec.js
+++ b/tests/unit/utils/url-helper.spec.js
@@ -11,8 +11,14 @@
 import {
   areEquivalentLocations,
   buildUrl,
+  resolveAbsoluteUrl,
 } from 'docc-render/utils/url-helper';
 import TechnologiesQueryParams from 'docc-render/constants/TechnologiesQueryParams';
+
+const mockBaseUrl = jest.fn().mockReturnValue('/');
+jest.mock('@/utils/theme-settings', () => ({
+  get baseUrl() { return mockBaseUrl(); },
+}));
 
 describe('areEquivalentLocations', () => {
   it('returns false for the same route with a different path', () => {
@@ -128,5 +134,24 @@ describe('buildUrl', () => {
 
   it('appends query params to urls with hash tags and existing queries', () => {
     expect(buildUrl('/docs?foo=bar#hash', { changes: 'abc' })).toEqual('/docs?foo=bar&changes=abc#hash');
+  });
+});
+
+describe('resolveAbsoluteUrl', () => {
+  it('returns an absolute URL for a relative path', () => {
+    expect(resolveAbsoluteUrl('/foo/bar')).toBe('http://localhost/foo/bar');
+  });
+
+  it('includes the host and base path of the current environment', () => {
+    const { location } = window;
+
+    mockBaseUrl.mockReturnValue('/foo');
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://example.com'),
+    });
+    expect(resolveAbsoluteUrl('/bar/baz')).toBe('https://example.com/foo/bar/baz');
+
+    mockBaseUrl.mockReturnValue('/');
+    Object.defineProperty(window, 'location', { value: location });
   });
 });

--- a/tests/unit/utils/url-helper.spec.js
+++ b/tests/unit/utils/url-helper.spec.js
@@ -138,11 +138,12 @@ describe('buildUrl', () => {
 });
 
 describe('resolveAbsoluteUrl', () => {
-  it('returns an absolute URL for a relative path', () => {
+  it('returns an absolute URL for a given path', () => {
     expect(resolveAbsoluteUrl('/foo/bar')).toBe('http://localhost/foo/bar');
+    expect(resolveAbsoluteUrl('foo/bar')).toBe('http://localhost/foo/bar');
   });
 
-  it('includes the host and base path of the current environment', () => {
+  it('resolves against the host and base path of the current environment', () => {
     const { location } = window;
 
     mockBaseUrl.mockReturnValue('/foo');
@@ -150,8 +151,18 @@ describe('resolveAbsoluteUrl', () => {
       value: new URL('https://example.com'),
     });
     expect(resolveAbsoluteUrl('/bar/baz')).toBe('https://example.com/foo/bar/baz');
+    expect(resolveAbsoluteUrl('foobar/baz')).toBe('https://example.com/foobar/baz');
 
     mockBaseUrl.mockReturnValue('/');
     Object.defineProperty(window, 'location', { value: location });
+  });
+
+  it('can resolve against a provided base URL', () => {
+    expect(resolveAbsoluteUrl('/foo/bar', 'https://swift.org'))
+      .toBe('https://swift.org/foo/bar');
+    expect(resolveAbsoluteUrl('foobar', 'https://swift.org'))
+      .toBe('https://swift.org/foobar');
+    expect(resolveAbsoluteUrl('foo/bar', 'https://swift.org/blah'))
+      .toBe('https://swift.org/foo/bar');
   });
 });


### PR DESCRIPTION
This updates https://github.com/apple/swift-docc-render/pull/46 to use absolute URLs instead of relative paths for metadata.

\cc @dobromir-hristov