### PR TITLE
Small metadata refactoring

### DIFF
--- a/src/utils/metadata.js
+++ b/src/utils/metadata.js
@@ -75,20 +75,15 @@ const addOrUpdateMetaTag = (metadata) => {
   const ref = metadata[key];
 
   const existingMetaElement = document.querySelector(`meta[${key}="${ref}"]`);
-  if (existingMetaElement) {
-    if (content) {
-      existingMetaElement.setAttribute('content', content);
-    } else {
-      existingMetaElement.remove();
-    }
-  } else {
-    // eslint-disable-next-line no-lonely-if
-    if (content) {
-      const newMetaElement = document.createElement('meta');
-      newMetaElement.setAttribute(key, metadata[key]);
-      newMetaElement.setAttribute('content', metadata.content);
-      document.getElementsByTagName('head')[0].appendChild(newMetaElement);
-    }
+  if (existingMetaElement && content) {
+    existingMetaElement.setAttribute('content', content);
+  } else if (existingMetaElement && !content) {
+    existingMetaElement.remove();
+  } else if (content) {
+    const newMetaElement = document.createElement('meta');
+    newMetaElement.setAttribute(key, metadata[key]);
+    newMetaElement.setAttribute('content', metadata.content);
+    document.getElementsByTagName('head')[0].appendChild(newMetaElement);
   }
 };
 


### PR DESCRIPTION
This is a very small PR to add some last minute refactoring to address the remaining comments on https://github.com/apple/swift-docc-render/pull/46

* removes logic depending on the ordering of `Object.keys`
* updates DOM logic to only query `<meta>` elements once (per item)