### PR TITLE
Improve routes order

### DIFF
--- a/src/components/ContentNode/Reference.vue
+++ b/src/components/ContentNode/Reference.vue
@@ -70,7 +70,7 @@ export default {
       } = this.$router.resolve(url) || {};
 
       // Resolved internal URLs don't have the "not found" route.
-      return name !== notFoundRouteName;
+      return !name.startsWith(notFoundRouteName);
     },
     isSymbolReference() {
       return this.kind === 'symbol' && !this.hasInlineFormatting

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,7 +16,20 @@ import {
 import ServerError from 'theme/views/ServerError.vue';
 import NotFound from 'theme/views/NotFound.vue';
 
-export default [
+export const fallbackRoutes = [
+  {
+    path: '*',
+    name: notFoundRouteName,
+    component: NotFound,
+  },
+  {
+    path: '*', // purposefully unreachable without a forced navigation
+    name: serverErrorRouteName,
+    component: ServerError,
+  },
+];
+
+export const pagesRoutes = [
   {
     path: '/tutorials/:id',
     name: 'tutorials-overview',
@@ -38,14 +51,9 @@ export default [
       /* webpackChunkName: "documentation-topic" */ 'theme/views/DocumentationTopic.vue'
     ),
   },
-  {
-    path: '*',
-    name: notFoundRouteName,
-    component: NotFound,
-  },
-  {
-    path: '*', // purposefully unreachable without a forced navigation
-    name: serverErrorRouteName,
-    component: ServerError,
-  },
+];
+
+export default [
+  ...pagesRoutes,
+  ...fallbackRoutes,
 ];

--- a/src/setup-utils/SwiftDocCRenderRouter.js
+++ b/src/setup-utils/SwiftDocCRenderRouter.js
@@ -18,16 +18,17 @@ import {
   restoreScrollOnReload,
   scrollBehavior,
 } from 'docc-render/utils/router-utils';
-import routes from 'docc-render/routes';
+import routes, { pagesRoutes, fallbackRoutes } from 'docc-render/routes';
 import { baseUrl } from 'docc-render/utils/theme-settings';
 import { addPrefixedRoutes } from 'docc-render/utils/route-utils';
 
 const defaultRoutes = [
-  ...routes,
+  ...pagesRoutes,
   ...addPrefixedRoutes(routes, [
     notFoundRouteName,
     serverErrorRouteName,
   ]),
+  ...fallbackRoutes,
 ];
 
 export default function createRouterInstance(routerConfig = {}) {

--- a/src/setup-utils/SwiftDocCRenderRouter.js
+++ b/src/setup-utils/SwiftDocCRenderRouter.js
@@ -10,10 +10,6 @@
 
 import Router from 'vue-router';
 import {
-  notFoundRouteName,
-  serverErrorRouteName,
-} from 'docc-render/constants/router';
-import {
   saveScrollOnReload,
   restoreScrollOnReload,
   scrollBehavior,
@@ -24,10 +20,7 @@ import { addPrefixedRoutes } from 'docc-render/utils/route-utils';
 
 const defaultRoutes = [
   ...pagesRoutes,
-  ...addPrefixedRoutes(routes, [
-    notFoundRouteName,
-    serverErrorRouteName,
-  ]),
+  ...addPrefixedRoutes(routes),
   ...fallbackRoutes,
 ];
 

--- a/src/setup-utils/SwiftDocCRenderRouter.js
+++ b/src/setup-utils/SwiftDocCRenderRouter.js
@@ -14,12 +14,11 @@ import {
   restoreScrollOnReload,
   scrollBehavior,
 } from 'docc-render/utils/router-utils';
-import routes, { pagesRoutes, fallbackRoutes } from 'docc-render/routes';
+import routes, { fallbackRoutes } from 'docc-render/routes';
 import { baseUrl } from 'docc-render/utils/theme-settings';
 import { addPrefixedRoutes } from 'docc-render/utils/route-utils';
 
 const defaultRoutes = [
-  ...pagesRoutes,
   ...addPrefixedRoutes(routes),
   ...fallbackRoutes,
 ];

--- a/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
+++ b/tests/unit/setup-utils/SwiftDocCRenderRouter.spec.js
@@ -118,8 +118,8 @@ describe('SwiftDocCRenderRouter', () => {
 
     const resolve = path => router.resolve(path).route;
 
-    it('resolves paths to the "tutorials-overview" route', () => {
-      const route = 'tutorials-overview';
+    it('resolves paths to the "tutorials-overview-locale" route', () => {
+      const route = 'tutorials-overview-locale';
 
       expect(resolve('/tutorials/foo').name).toBe(route);
       expect(resolve('/tutorials/bar').name).toBe(route);
@@ -140,8 +140,8 @@ describe('SwiftDocCRenderRouter', () => {
       expect(resolve('/zh-CN/tutorials/foo/bar').name).not.toBe(route);
     });
 
-    it('resolves paths to the "topic" route', () => {
-      const route = 'topic';
+    it('resolves paths to the "topic-locale" route', () => {
+      const route = 'topic-locale';
       expect(resolve('/tutorials/foo/bar').name).toBe(route);
       expect(resolve('/tutorials/foobar/baz').name).toBe(route);
       expect(resolve('/tutorials/documentation/foo').name).toBe(route);
@@ -163,8 +163,8 @@ describe('SwiftDocCRenderRouter', () => {
       });
     });
 
-    it('resolves paths to the "documentation-topic" route', () => {
-      const route = 'documentation-topic';
+    it('resolves paths to the "documentation-topic-locale" route', () => {
+      const route = 'documentation-topic-locale';
 
       expect(resolve('/documentation/foo').name).toBe(route);
       expect(resolve('/documentation/bar').name).toBe(route);


### PR DESCRIPTION
Bug/issue #161830978, if applicable: 

## Summary

The new order for our routes should be:
- Localized page routes
- Localized fallback routes
- Fallback routes ([Vue Router requires explicit catch-all routes for not-found handling)](https://v3.router.vuejs.org/guide/essentials/dynamic-matching.html#catch-all-404-not-found-route))

Since the param locale is optional: `/:locale?/`
we can delete the original page routes and only left the localisation routes.

Before, the order was:

```js
[
    {
        "path": "/tutorials/:id",
        "name": "tutorials-overview"
    },
    {
        "path": "/tutorials/:id/*",
        "name": "topic"
    },
    {
        "path": "/documentation*",
        "name": "documentation-topic"
    },
    {
        "path": "*",
        "name": "not-found",
        "component": {...}
    },
    {
        "path": "*",
        "name": "server-error",
        "component": {...}
    },
    {
        "path": "/:locale?/tutorials/:id",
        "name": "tutorials-overview-locale"
    },
    {
        "path": "/:locale?/tutorials/:id/*",
        "name": "topic-locale"
    },
    {
        "path": "/:locale?/documentation*",
        "name": "documentation-topic-locale"
    }
]
```

now it is:

```js
[
    {
        "path": "/:locale?/tutorials/:id",
        "name": "tutorials-overview-locale"
    },
    {
        "path": "/:locale?/tutorials/:id/*",
        "name": "topic-locale"
    },
    {
        "path": "/:locale?/documentation*",
        "name": "documentation-topic-locale"
    },
    {
        "path": "/:locale?/*",
        "name": "not-found-locale",
        "component": {...}
    },
    {
        "path": "/:locale?/*",
        "name": "server-error-locale",
        "component": {...}
    },
    {
        "path": "*",
        "name": "not-found",
        "component": {...}
    },
    {
        "path": "*",
        "name": "server-error",
        "component": {...}
    },
]
```
## Dependencies

https://github.com/swiftlang/swift-docc-render/pull/970

## Testing

Steps:
1. Make sure that current routes work fine

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
