### PR TITLE
Add no-label aside kind that suppresses the callout heading

### DIFF
--- a/src/components/ContentNode/Aside.vue
+++ b/src/components/ContentNode/Aside.vue
@@ -10,7 +10,7 @@
 
 <template>
   <aside :class="kind" :aria-label="kind">
-    <p class="label">{{ name || $t(label) }}</p>
+    <p v-if="!isNoLabel" class="label">{{ name || $t(label) }}</p>
     <slot />
   </aside>
 </template>
@@ -20,6 +20,7 @@ const Kind = {
   deprecated: 'deprecated',
   experiment: 'experiment',
   important: 'important',
+  'no-label': 'no-label',
   note: 'note',
   tip: 'tip',
   warning: 'warning',
@@ -40,6 +41,7 @@ export default {
   },
   computed: {
     label: ({ kind }) => `aside-kind.${kind}`,
+    isNoLabel: ({ kind }) => kind === Kind['no-label'],
   },
 };
 </script>
@@ -47,7 +49,7 @@ export default {
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 
-$aside-kinds: deprecated, experiment, important, note, tip, warning;
+$aside-kinds: deprecated, experiment, important, no-label, note, tip, warning;
 
 aside {
   break-inside: avoid;

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -61,6 +61,7 @@
           :class="{ 'minimized-abstract': enableMinimized }"
           :content="abstract"
         />
+        <slot name="below-abstract" />
         <div v-if="sampleCodeDownload">
           <DownloadButton
             class="sample-download"

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -44,6 +44,9 @@
   --color-aside-important: var(--color-figure-gray);
   --color-aside-important-background: var(--color-fill-gray-secondary);
   --color-aside-important-border: var(--color-figure-light-gray);
+  --color-aside-no-label: var(--color-figure-gray);
+  --color-aside-no-label-background: var(--color-fill-gray-secondary);
+  --color-aside-no-label-border: var(--color-figure-light-gray);
   --color-aside-note: var(--color-figure-gray);
   --color-aside-note-background: var(--color-fill-gray-secondary);
   --color-aside-note-border: var(--color-figure-light-gray);

--- a/tests/unit/components/ContentNode/Aside.spec.js
+++ b/tests/unit/components/ContentNode/Aside.spec.js
@@ -59,6 +59,19 @@ describe('Aside', () => {
     expect(label.text()).toBe('Custom Name');
   });
 
+  it('does not render a label for no-label kind', () => {
+    const wrapper = shallowMount(Aside, {
+      propsData: {
+        kind: 'no-label',
+      },
+      slots: {
+        default: '<p>content</p>',
+      },
+    });
+    expect(wrapper.classes('no-label')).toBe(true);
+    expect(wrapper.find('.label').exists()).toBe(false);
+  });
+
   it('renders slot content', () => {
     const wrapper = shallowMount(Aside, {
       propsData: {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -1121,6 +1121,19 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find('.above-hero-content').exists()).toBe(true);
   });
 
+  it('renders content in the `below-abstract` slot', () => {
+    wrapper = shallowMount(DocumentationTopic, {
+      propsData,
+      slots: {
+        'below-abstract': '<div class="below-abstract">Below Abstract Content</div>',
+      },
+      provide: {
+        store: mockStore,
+      },
+    });
+    expect(wrapper.findComponent(DocumentationHero).find('.below-abstract').exists()).toBe(true);
+  });
+
   it('renders `OnThisPageNav` component, if enabled via prop', async () => {
     expect(wrapper.findComponent(OnThisPageNav).exists()).toBe(false);
     expect(wrapper.findComponent(OnThisPageStickyContainer).exists()).toBe(false);


### PR DESCRIPTION
Bug/issue #176906827, if applicable: 

## Summary

When a documentation author needs a visually styled callout that carries no semantic heading, such as a plain highlighted block, there is no way to suppress the label since very valid kind produces a label.

A new kind `no-label` is introduced. When `kind="no-label"` is set, the `isNoLabel` computed property returns true, and the `v-if="!isNoLabel"` directive on the label `<p>` causes it to be omitted from the rendered output entirely. The aside block itself still renders with its border, background, and box-shadow styling.

This new type has the same neutral palette values used by `note` and `important`, giving the labelless aside a visually consistent appearance with the existing neutral-tone callouts.

## Dependencies

https://github.com/swiftlang/swift-docc-render/pull/1017

## Testing

Steps:
1. Add an aside with type `no-label` to your `doccarchive`

```json
{
  "name": "Aside",
  "style": "no-label",
  "content": [
    {
      "type": "paragraph",
      "inlineContent": [
        {
          "type": "text",
          "text": "Content for aside"
        }
      ]
    }
  ],
  "type": "aside"
}
```

2. Assert that it doesn't render the label.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
